### PR TITLE
[ADD]add the support of map by tag

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -32,3 +32,47 @@ func StructMapByFieldName(src interface{}, dest interface{}) error {
 
 	return nil
 }
+
+func StructMapByTag(src interface{}, dest interface{}) error {
+	//not addressable
+	if reflect.TypeOf(src).Kind() != reflect.Ptr && reflect.TypeOf(dest).Kind() != reflect.Ptr {
+		return errors.New("src and dst must be addressable.")
+	}
+
+	tSrc, vSrc, tDst, vDst := reflect.TypeOf(src).Elem(), reflect.ValueOf(src).Elem(),
+		reflect.TypeOf(dest).Elem(), reflect.ValueOf(dest).Elem()
+
+	//建立一个map存储字段与我们的tag的映射关系
+	tagMap := make(map[string]reflect.Value)
+
+	//首先遍历我们的dst，将所有的tag与对应的字段映射起来
+	for i := 0; i < vDst.NumField(); i++ {
+		if val, ok := tDst.Field(i).Tag.Lookup("mapper"); ok {
+			tagMap[val] = vDst.Field(i)
+		}
+	}
+	//然后遍历我们的request，遍历所有的field，每次获取到tag，然后填充对应的内容到我们的resp的field中
+	for i := 0; i < vSrc.NumField(); i++ {
+		if val, ok := tSrc.Field(i).Tag.Lookup("mapper"); ok {
+			//通过val与tagMap找到对应于vDst的字段
+			//有可能map中的值不存在
+			if value, ok := tagMap[val]; ok && value.IsValid() && value.CanSet() && vSrc.Field(i).Kind() == value.Kind() {
+				switch value.Kind() {
+				case reflect.Int:
+					value.SetInt(vSrc.Field(i).Int())
+				case reflect.Bool:
+					value.SetBool(vSrc.Field(i).Bool())
+				case reflect.Uint:
+					value.SetUint(vSrc.Field(i).Uint())
+				case reflect.Float64:
+					value.SetFloat(vSrc.Field(i).Float())
+				case reflect.Complex64:
+					value.SetComplex(vSrc.Field(i).Complex())
+				case reflect.String:
+					value.SetString(vSrc.Field(i).String())
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -8,21 +8,21 @@ import (
 
 //declare struct
 type Src struct {
-	A string
-	B int
-	C bool
-	D []string
-	AnonymousTest
-	int
+	A             string   `mapper:"A"`
+	B             int      `mapper:"B"`
+	C             bool     `mapper:"C"`
+	D             []string `mapper:"D"`
+	AnonymousTest `mapper:"E"`
+	int           `mapper:"F"`
 }
 
 type Dest struct {
-	A string
-	B int
-	C bool
-	D []string
-	AnonymousTest
-	int
+	A             string   `mapper:"A"`
+	B             int      `mapper:"B"`
+	C             bool     `mapper:"C"`
+	D             []string `mapper:"D"`
+	AnonymousTest `mapper:"E"`
+	int           `mapper:"F"`
 }
 
 type AnonymousTest struct {
@@ -52,15 +52,33 @@ func TestMain(m *testing.M) {
 func TestStructMapByFieldName(t *testing.T) {
 	//arrange
 	expect_dest := Dest{
-		A:             Test_Src.A,
-		B:             Test_Src.B,
-		C:             Test_Src.C,
-		D:             Test_Src.D,
-		AnonymousTest: Test_Src.AnonymousTest,
+		A: Test_Src.A,
+		B: Test_Src.B,
+		C: Test_Src.C,
 	}
 
 	//act
 	err := StructMapByFieldName(&Test_Src, &Test_Dest)
+	if err != nil {
+		t.Errorf("type error:%s", err)
+	}
+
+	//assert
+	if !reflect.DeepEqual(expect_dest, Test_Dest) {
+		t.Errorf("expect:%v,actual:%v", expect_dest, Test_Dest)
+	}
+}
+
+func TestStructMapByTag(t *testing.T) {
+	//arrange
+	expect_dest := Dest{
+		A: Test_Src.A,
+		B: Test_Src.B,
+		C: Test_Src.C,
+	}
+
+	//act
+	err := StructMapByTag(&Test_Src, &Test_Dest)
 	if err != nil {
 		t.Errorf("type error:%s", err)
 	}
@@ -76,5 +94,11 @@ func TestStructMapByFieldName(t *testing.T) {
 func BenchmarkStructMapByFieldName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		StructMapByFieldName(&Test_Src, &Test_Dest)
+	}
+}
+
+func BenchmarkStructMapByTag(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		StructMapByTag(&Test_Src, &Test_Dest)
 	}
 }

--- a/samples/main.go
+++ b/samples/main.go
@@ -1,29 +1,41 @@
 package main
 
-import "github.com/Codexiaoyi/go-mapper"
+import (
+	"fmt"
+
+	"github.com/Codexiaoyi/go-mapper"
+)
 
 type src struct {
-	A string
-	B int
+	A string `mapper:"a"`
+	B int    `mapper:"B"`
 	C bool
 }
 
 type dest struct {
-	A string
-	B int
+	A string `mapper:"a"`
+	B int    `mapper:"B"`
 	C bool
 }
 
 func main() {
 	var src src
-	var dest dest
+	var dest1 dest
 	src.A = "aaa"
 	src.B = 1
 	src.C = true
 
-	err := mapper.StructMapByFieldName(&src, &dest)
+	err := mapper.StructMapByFieldName(&src, &dest1)
 	if err != nil {
 		println(err)
 	}
-	println(dest.A, dest.B, dest.C)
+	println(dest1.A, dest1.B, dest1.C)
+
+	var dest2 dest
+
+	err = mapper.StructMapByTag(&src, &dest2)
+	if err != nil {
+		fmt.Println(err)
+	}
+	println(dest2.A, dest2.B, dest2.C)
 }


### PR DESCRIPTION
1. add the support of map by tag
2. It will be mapped if the tag with the mapper is added and the corresponding name is the same.
```go
type src struct {
	A string `mapper:"a"`
	B int    `mapper:"B"`
	C bool
}

type dest struct {
	A string `mapper:"a"`
	B int    `mapper:"B"`
	C bool
}

func main() {
	var src src
	var dest1 dest
	src.A = "aaa"
	src.B = 1
	src.C = true

	err := mapper.StructMapByFieldName(&src, &dest1)
	if err != nil {
		println(err)
	}
	println(dest1.A, dest1.B, dest1.C)

	var dest2 dest

	err = mapper.StructMapByTag(&src, &dest2)
	if err != nil {
		fmt.Println(err)
	}
	println(dest2.A, dest2.B, dest2.C)
}
```
